### PR TITLE
データセットをurlからダウンロードするスクリプトを組む

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+datasets/
+
+*.txt
+
+**/images/
+**/labels/
+
+*.jpeg
+*.jpg
+*.png
+
+*.zip
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 サトウキビとパイナップルのデータがありますが、手動でダウンロードするのは面倒なので下記コマンドを実行してdatasetsをダウンロードしてください。
 
 ```bash
-# Sugarcane Version 4
-$sugarcane_url="https://app.roboflow.com/ds/T2zV0t9XVG?key=VldKEnvBjY"
+# Sugarcane Version 5
+$sugarcane_url="https://app.roboflow.com/ds/gethDX7bpc?key=l2lWEbZzPK"
 # Pineapple Version 2
 $pineapple_url="https://app.roboflow.com/ds/hfpq9ajFvM?key=5Rq1mFJi7w"
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # manage-dataset
-データセット関連のrepo
+
+学習で使うデータセットを管理しているリポジトリです。
+
+学習に使用するデータセットは[Roboflow](https://universe.roboflow.com/techcsugarcane/)というサービスを使用して作成しています。
+
+## ダウンロード
+
+サトウキビとパイナップルのデータがありますが、手動でダウンロードするのは面倒なので下記コマンドを実行してdatasetsをダウンロードしてください。
+
+```bash
+# Sugarcane Version 4
+$sugarcane_url="https://app.roboflow.com/ds/T2zV0t9XVG?key=VldKEnvBjY"
+# Pineapple Version 2
+$pineapple_url="https://app.roboflow.com/ds/hfpq9ajFvM?key=5Rq1mFJi7w"
+
+# mac向け
+bash download_dataset.sh $sugarcane_url $pineapple_url
+
+# windows向け
+./download_dataset.ps1 -SugarcaneUrl $sugarcane_url -PineappleUrl $pineapple_url
+```

--- a/download_dataset.ps1
+++ b/download_dataset.ps1
@@ -1,0 +1,43 @@
+# winget install --id GnuWin32.UnZip
+
+param(
+    [string]$SugarcaneUrl,
+    [string]$PineappleUrl
+)
+
+$dataset_dir = "datasets"
+
+function Download-Dataset {
+    param (
+        [string]$name,
+        [string]$url
+    )
+
+    $download_dataset_dir = "$dataset_dir\$name"
+    if (Test-Path -Path $download_dataset_dir) {
+        Write-Host "$name dataset already exists."
+        $response = Read-Host "Do you want to remove it? (y/n)"
+        if ($response -eq 'y' -or $response -eq 'Y') {
+            Remove-Item -Recurse -Force -Path $download_dataset_dir
+        } else {
+            exit 0
+        }
+    }
+
+    New-Item -ItemType Directory -Path $download_dataset_dir | Out-Null
+    Write-Host "Downloading $name dataset..."
+    Invoke-WebRequest -Uri $url -OutFile "roboflow.zip"
+    Expand-Archive -Path "roboflow.zip" -DestinationPath $download_dataset_dir
+    Remove-Item -Path "roboflow.zip"
+
+    # data.yamlを書き換える
+    (Get-Content "$download_dataset_dir\data.yaml") -replace "\.\.\/", "../manage-dataset/$dataset_dir/$name/" | Set-Content "$download_dataset_dir\data.yaml"
+
+    Write-Host "$name dataset downloaded."
+}
+
+# Download sugarcane dataset
+Download-Dataset -name "sugarcane" -url $SugarcaneUrl
+
+# Download pineapple dataset
+Download-Dataset -name "pineapple" -url $PineappleUrl

--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -1,0 +1,32 @@
+
+sugarcane_url=${1}
+pineapple_url=${2}
+
+dataset_dir="datasets"
+
+download_dataset() {
+    download_dataset_dir="${dataset_dir}/${1}"
+    if [ -d ${download_dataset_dir} ]; then
+        echo "${1} dataset already exists."
+        read -p "Do you want to remove it? (y/n) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            rm -rf ${download_dataset_dir}
+        else
+            exit 0
+        fi
+    fi
+    mkdir -p ${download_dataset_dir}
+    echo "Downloading ${1} dataset..."
+    curl -L ${2} > roboflow.zip; unzip roboflow.zip -d ${download_dataset_dir}; rm roboflow.zip
+
+    # data.yamlを書き換える
+    sed -i -e "s/\.\.\//\.\.\/manage-dataset\/${download_dataset_dir}\//g" ${download_dataset_dir}/data.yaml
+
+    echo "${1} dataset downloaded."
+}
+# Download sugarcane dataset
+download_dataset "sugarcane" ${sugarcane_url}
+
+# Download pineapple dataset
+download_dataset "pineapple" ${pineapple_url}


### PR DESCRIPTION
## 概要

毎回huggingfaceにデータセットをダウンロードするのが手間だったので、自動でダウンロードしてくるようにしました。
また、YOLOシリーズのデータセットの形式が同じだったので、全てこのデータセットから学習するように変更しました。


## 変更内容
<!--
このPRで行った変更の内容を記述。
変更内容はできるだけ詳細に、わかりやすく記述してください。
-->


## 関連Issue, PR
<!--
関連するIssue番号, PR番号を箇条書きで記載してください。
番号の前に、明示的に"Close"を書くと、マージした際に自動的にIssueが閉じられます。
関連Issueが存在しない場合は、記述しなくて大丈夫です。

（例）
- #0          // PRにIssuesや別のPRを紐づける
- Close #1    // Issueを自動的にクローズ
-->


## その他

データセットのダウンロードについて、windowsは動作確認済みですが、macはまだです